### PR TITLE
flake: prune dev deps to avoid isolated-vm crash on Node 24

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,13 @@
 
             installPhase = ''
               runHook preInstall
+
+              # Prune dev dependencies so transitive deps like isolated-vm
+              # (from n8n-workflow -> @n8n/expression-runtime) don't end up
+              # in the output.  n8n-workflow is a peerDependency provided by
+              # the n8n runtime, so it must not be bundled.
+              npm prune --omit=dev --legacy-peer-deps
+
               mkdir -p $out/lib/node_modules/n8n-nodes-caldav
               cp -r dist package.json node_modules $out/lib/node_modules/n8n-nodes-caldav/
               runHook postInstall


### PR DESCRIPTION
n8n-workflow is a devDependency (needed for tsc/tests) that transitively pulls in @n8n/expression-runtime -> isolated-vm. The prebuilt isolated-vm native addon (abi137) hits a V8 assertion failure on Node 24:

```
isolate.cc:100: void ivm::init(): Assertion
'isolates->find(isolate) == isolates->end()' failed.
```

Since n8n-workflow is also declared as a peerDependency (provided by the n8n runtime), there's no reason to ship it or its transitive deps in the package output. Running `npm prune --omit=dev` strips isolated-vm and other unnecessary dev-only transitive dependencies.